### PR TITLE
Migration Java9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ subprojects {
     apply plugin: 'maven-publish'
     apply plugin: "com.github.johnrengelman.shadow"
 
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_1_9
+    targetCompatibility = JavaVersion.VERSION_1_9
 
     ext {
         nexusPublicReleasesUrl = 'https://mojo-maven.cs.fau.de/repository/public-releases/'

--- a/docker/ods/Dockerfile
+++ b/docker/ods/Dockerfile
@@ -1,6 +1,6 @@
 #REPO: mojo-docker.cs.fau.de/osrg_ods_public/ods
 
-FROM adoptopenjdk/openjdk8-openj9:alpine
+FROM adoptopenjdk/openjdk9-openj9:alpine
 
 ENV ODS_LOG_DIR /var/log/ods
 


### PR DESCRIPTION
migrated to Java9 / JDK 1.9 in order to use the Java Modules feature.

Make sure to have the right JDK installed, configured as JAVA_HOME and adapt your IDE if you are still on JDK 1.8